### PR TITLE
Jenkins: migration to new instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,8 @@ timeout(time: 60, unit: 'MINUTES') {
         podAnnotation(key: 'botkube.io/channel', value: 'university-k8s')
       ],
       cloud: 'k8s-ci-cd',
-      inheritFrom: 'pod-base-configuration',
+      namespace: 'lae-jenkins',
+      inheritFrom: 'pod-base-configuration-with-dind',
       containers: [
         containerTemplate(
           name: 'linux',


### PR DESCRIPTION
- Jenkins:
  - Jenkinsfile adjusted for new Jenkins

N.B.: if you want to have other branches working in the new Jenkins, you will have to merge _main_ into them; old git tags and releases won’t work either, so you will need to create new ones to deploy